### PR TITLE
Use gulp to compile and launch app

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Arma3 mission replays.
 * `npm install`
 * edit configuration file, see `config.json.example`
 * optionally add authentication file, see `config.json.example` and `auth.ini.example`
-* start this thing
+* start this thing with `npm start`
 * start your armaserver with the sock extension pointing at host/port specified in config.json
 
 # API

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,29 @@
+var exec = require('child_process').exec;
+var gulp = require('gulp');
+var tsd = require('gulp-tsd');
+var typescript = require('gulp-tsc');
+
+gulp.task('default', ['app'], function () {
+  
+});
+
+gulp.task('app', ['tsc'], function (cb) {
+  // launch app
+  exec('node main.js', function(err) {
+    if (err) return cb(err); // return error
+    cb(); // finished task
+  });
+});
+
+gulp.task('tsc', ['tsd'], function () {
+  return gulp.src(['main.ts'])
+    .pipe(typescript())
+    .pipe(gulp.dest('.'))
+});
+ 
+gulp.task('tsd', function (callback) {
+    tsd({
+        command: 'reinstall',
+        config: './tsd.json'
+    }, callback);
+});

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
     "ini": "~1.3.3"
   },
   "scripts": {
-    "install": "./node_modules/tsd/build/cli.js reinstall --save --override; node_modules/typescript/bin/tsc --module commonjs  ./*.ts */*.ts"
+    "start": "node_modules/.bin/gulp"
+  },
+  "devDependencies": {
+    "gulp": "^3.8.11",
+    "gulp-tsc": "^0.9.4",
+    "gulp-tsd": "0.0.4"
   }
 }


### PR DESCRIPTION
Gulp now does the tsd and tsc build step and then launches the app

To start the build process and the app just do `npm start`

Fixes #3
